### PR TITLE
Dockerise Hr api and add instructions for dapr ingress controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ Install Dapr on the cluster (https://docs.dapr.io/operations/hosting/kubernetes/
 dapr init -k
 ```
 
-Install the Hello Kubernetes Quickstart example Node App. <node.yaml> is https://github.com/dapr/quickstarts/blob/master/hello-kubernetes/deploy/node.yaml. This also installs the Dapr side car, as defined in the yaml
+Install the Hello Kubernetes Quickstart example Node App. This also installs the Dapr side car, as defined in the yaml
 
 ```bash
-kubectl apply -f <node.yaml>
+kubectl apply -f https://github.com/dapr/quickstarts/blob/master/hello-kubernetes/deploy/node.yaml
 ```
 
 Install the nginx ingress controller

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Create a kubernetes cluster somewhere
 gcloud container clusters create dapr --num-nodes=1
 ```
 
-Install Dapr on the cluster
+Install Dapr on the cluster (https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-deploy/)
 
 ```bash
 dapr init -k

--- a/lib/hr/Dockerfile
+++ b/lib/hr/Dockerfile
@@ -1,0 +1,33 @@
+FROM rust:1.51 AS build
+
+RUN rustup component add rustfmt clippy
+
+COPY Cargo.toml Cargo.lock ./
+
+RUN mkdir -p ./src/ && echo 'fn main() {}' >./src/main.rs
+RUN cargo build --release && rm -rf ./target/release/.fingerprint/hr-*
+
+COPY src ./src
+
+RUN cargo clippy --release -- -D warnings && \
+    cargo build --release
+
+# ~~~~~~~~~~~~~~~~~~~~~~
+FROM debian:buster-slim as release
+
+RUN apt-get update && apt-get install -y \
+    openssl \
+    tini \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd svc
+USER svc
+
+COPY --chown=svc --from=build \
+    /target/release/hr \
+    /
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+EXPOSE 3000
+CMD ["/hr"]

--- a/lib/hr/Makefile
+++ b/lib/hr/Makefile
@@ -1,0 +1,27 @@
+app := slack
+image := ghcr.io/redbadger/$(app)
+tag := latest
+
+.PHONY: default
+default: build push
+
+.PHONY: build
+build: ## Build Docker image
+	docker build --progress=plain -t $(image):latest -t $(image):$(tag) .
+
+.PHONY: push
+push: ## Push images to registry
+	docker push $(image):latest
+	docker push $(image):$(tag)
+
+.PHONY: run
+run: ## Runs the docker image
+	docker run -it -p 3000:3000 $(image):latest
+
+.PHONY: run-ci
+run-ci: ## Runs the docker image in CI
+	docker run -p 3000:3000 $(image):latest
+
+.PHONY: help
+help: ## Display this help screen
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/lib/hr/Makefile
+++ b/lib/hr/Makefile
@@ -1,4 +1,4 @@
-app := slack
+app := hr
 image := ghcr.io/redbadger/$(app)
 tag := latest
 

--- a/lib/hr/src/main.rs
+++ b/lib/hr/src/main.rs
@@ -16,7 +16,7 @@ fn main() -> Result<()> {
 }
 
 async fn run() -> Result<()> {
-    let listen_addr = env::var("LISTEN_ADDR").unwrap_or_else(|_| "localhost:8000".to_owned());
+    let listen_addr = env::var("PORT").unwrap_or_else(|_| "0.0.0.0:3000".to_owned());
 
     let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription).finish();
 

--- a/lib/hr/src/main.rs
+++ b/lib/hr/src/main.rs
@@ -16,11 +16,11 @@ fn main() -> Result<()> {
 }
 
 async fn run() -> Result<()> {
-    let listen_addr = env::var("PORT").unwrap_or_else(|_| "0.0.0.0:3000".to_owned());
+    let host_and_port = env::var("LISTEN_HOST_AND_PORT").unwrap_or_else(|_| "0.0.0.0:3000".to_owned());
 
     let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription).finish();
 
-    println!("Playground: http://{}", listen_addr);
+    println!("Playground: http://{}", host_and_port);
 
     let mut app = tide::new();
 
@@ -36,7 +36,7 @@ async fn run() -> Result<()> {
         Ok(resp)
     });
 
-    app.listen(listen_addr).await?;
+    app.listen(host_and_port).await?;
 
     Ok(())
 }

--- a/manifests/hr/deployment.yaml
+++ b/manifests/hr/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hr
+  labels:
+    app: hr
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hr
+  template:
+    metadata:
+      labels:
+        app: hr
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "hr"
+        dapr.io/app-port: "3000"
+    spec:
+      serviceAccountName: hr-sa
+      containers:
+        - name: hr
+          image: ghcr.io/redbadger/hr:latest
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"

--- a/manifests/hr/kustomization.yaml
+++ b/manifests/hr/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: hr
+
+resources:
+- namespace.yaml
+- service-account.yaml
+- deployment.yaml
+- service.yaml
+
+images:
+- digest: sha256:f4a02a5547c0ee17cf36ccc40a15c44830c4be00f070f2842f9c725ece41ba22
+  name: ghcr.io/redbadger/hr
+  newName: ghcr.io/redbadger/hr

--- a/manifests/hr/namespace.yaml
+++ b/manifests/hr/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: slack
+  labels:
+    name: slack

--- a/manifests/hr/service-account.yaml
+++ b/manifests/hr/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hr-sa

--- a/manifests/hr/service.yaml
+++ b/manifests/hr/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hr
+  labels:
+    app: hr
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+  selector:
+    app: hr
+  type: LoadBalancer

--- a/manifests/hr/service.yaml
+++ b/manifests/hr/service.yaml
@@ -11,4 +11,4 @@ spec:
       targetPort: 3000
   selector:
     app: hr
-  type: LoadBalancer
+  type: ClusterIP

--- a/manifests/ingress-controller.yaml
+++ b/manifests/ingress-controller.yaml
@@ -1,0 +1,10 @@
+# helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+# helm repo update
+# helm install nginx-ingress ingress-nginx/ingress-nginx -f ./manifests/ingress-controller.yaml -n default
+controller:
+  podAnnotations:
+    dapr.io/enabled: "true"
+    # This has to match the name of the nginx controller as installed by helm, that is the <name> in `helm install <name>`
+    # Although the helm chart also contains nginx-express I think, so you have to `helm install nginx-ingress`
+    dapr.io/app-id: "nginx-ingress"
+    dapr.io/port: "80"

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -1,0 +1,17 @@
+# kubectl apply -f ./manifests/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: api-gateway-rules
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    - http:
+        paths:
+          # Only expose the Dapr invoke API, lets us call our services and nothing more
+          - path: /
+            backend:
+              serviceName: nginx-ingress-dapr
+              servicePort: 80                

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -10,7 +10,9 @@ spec:
   rules:
     - http:
         paths:
-          # Only expose the Dapr invoke API, lets us call our services and nothing more
+          # This is very much a work in progress, and currently allows everything through to make testing easier
+          # The end goal is probably to just expose the slack endpoint(s), and then the slack service will
+          # communicate internally with everything else (currently just the HR api).
           - path: /
             backend:
               serviceName: nginx-ingress-dapr


### PR DESCRIPTION
The dockerfile and associated stuff has been tested by building locally and installing on to a local minikube cluster. It has not been tested as part of the CI process.

To test this:

```bash
make build
make run
```

The Dapr ingress controller instructions are a work in progress, and currently work with the nodeapp yaml file and docker image from the Hello Kubernetes quickstart example project (the next step is to make it work with the fake HR api).

To test this follow the instructions in the readme
