### PR TITLE
Daprize slack service and expose through daprized ingress controller

### DIFF
--- a/manifests/hr/deployment.yaml
+++ b/manifests/hr/deployment.yaml
@@ -19,9 +19,11 @@ spec:
         dapr.io/app-port: "3000"
     spec:
       serviceAccountName: hr-sa
+      imagePullSecrets:
+        - name: github-container-registry
       containers:
         - name: hr
-          image: ghcr.io/redbadger/hr:latest
+          image: ghcr.io/redbadger/hr
           imagePullPolicy: Never
           ports:
             - containerPort: 3000

--- a/manifests/hr/namespace.yaml
+++ b/manifests/hr/namespace.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: slack
+  name: hr
   labels:
-    name: slack
+    name: hr

--- a/manifests/hr/service-account.yaml
+++ b/manifests/hr/service-account.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: hr-sa
+imagePullSecrets:
+  - name: github-container-registry

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -10,10 +10,10 @@ spec:
   rules:
     - http:
         paths:
-          # This is very much a work in progress, and currently allows everything through to make testing easier
-          # The end goal is probably to just expose the slack endpoint(s), and then the slack service will
-          # communicate internally with everything else (currently just the HR api).
-          - path: /
+          # All access with the outside world must be via dapr
+          # Currently slack is the only service we wish to expose
+          # `slack`.slack is from `dapr.io/app-id` in deployment.yaml and slack.`slack` is the namespace
+          - path: /v1.0/invoke/slack.slack/method/
             backend:
               serviceName: nginx-ingress-dapr
               servicePort: 80                

--- a/manifests/slack/deployment.yaml
+++ b/manifests/slack/deployment.yaml
@@ -13,8 +13,14 @@ spec:
     metadata:
       labels:
         app: slack
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "slack"
+        dapr.io/app-port: "3000"
     spec:
       serviceAccountName: slack-sa
+      imagePullSecrets:
+        - name: github-container-registry
       containers:
         - name: slack
           image: ghcr.io/redbadger/slack

--- a/manifests/slack/service-account.yaml
+++ b/manifests/slack/service-account.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: slack-sa
+imagePullSecrets:
+  - name: github-container-registry

--- a/manifests/slack/service.yaml
+++ b/manifests/slack/service.yaml
@@ -11,4 +11,4 @@ spec:
       targetPort: 3000
   selector:
     app: slack
-  type: ClusterIP
+  type: LoadBalancer


### PR DESCRIPTION
The slack service is now connected to Dapr

The cluster ingress rules restrict access to just the slack service (although currently the slack service can still be acessed directly, mainly to aid debugging, this is trivial to remove later)

To test this follow the "WIP: Deploy slack service to kubernetes" instructions in the readme.

There is still quite a lot of debugging type stuff in the readme and some of the kubernetes definition files, which I think will be helpful in the short term, but will probably be removed once things are more stable.