### PR TITLE
Hot reload the Slack Api

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Run the Slack and Hr Api's. The Slack Api will hot reload.
 
 ```
 cd lib/slack
-dapr run --app-id slack --app-port 3001 npm run dev
+dapr run --app-id slack --app-port 3001 yarn dev
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ Start Dapr locally
 dapr init
 ```
 
-Run the Slack and Hr Apis
+Run the Slack and Hr Api's. The Slack Api will hot reload.
 
 ```
 cd lib/slack
-dapr run --app-id slack --app-port 3001 npm start
+dapr run --app-id slack --app-port 3001 npm run dev
 ```
 
 ```

--- a/lib/slack/package.json
+++ b/lib/slack/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "scripts": {
     "start": "ts-node src/index.ts",
+    "dev": "concurrently \"tsc -w\" \"nodemon dist/index.js\"",
     "build": "tsc"
   },
   "dependencies": {
@@ -15,6 +16,8 @@
     "@types/express": "^4.17.11",
     "@types/node": "^14.14.37",
     "@types/node-fetch": "^2.5.10",
+    "concurrently": "^6.0.2",
+    "nodemon": "^2.0.7",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3"
   }

--- a/lib/slack/tsconfig.json
+++ b/lib/slack/tsconfig.json
@@ -10,6 +10,12 @@
     "strict": true,
     "esModuleInterop": true
   },
-  "exclude": ["node_modules", "dist"],
-  "include": ["**/*.ts"]
+  "compileOnSave": true,
+  "exclude": [
+    "node_modules",
+    "dist"
+  ],
+  "include": [
+    "**/*.ts"
+  ]
 }


### PR DESCRIPTION
Hot reloading is done with `npm run dev`

To test, follow the updated instructions in the readme under 'Running on local Dapr Instance', and make a change to the index.ts of the slack api while it is running from Dapr to confirm that it hot reloads, and continues to work as expected (use the http://localhost:3001/ping or http://localhost:3001/cedd/manager endpoints.