### PR TITLE
Zipkin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,17 @@ service := service-name
 
 repo := ghcr.io/redbadger
 
+workspace-root := $(shell git rev-parse --show-toplevel)
+dapr-config := $(workspace-root)/dapr-config-slim.yaml
+
 .PHONY: dev
 dev: ## runs all services and watches for changes
-	pnpx concurrently "make -C lib/hr dev" "make -C lib/slack dev"
+	pnpx concurrently --kill-others "make -C lib/hr dev" "make -C lib/slack dev"
+
+.PHONY: dev-trace
+dev-trace: ## runs all services and watches for changes
+	open http://localhost:9411/zipkin
+	$(MAKE) dapr-config=$(workspace-root)/dapr-config-trace.yaml dev
 
 .PHONY: ci
 ci: ## sets tag for deployment

--- a/dapr-config-trace.yaml
+++ b/dapr-config-trace.yaml
@@ -1,0 +1,9 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: daprConfig
+spec:
+  tracing:
+    samplingRate: "1"
+    zipkin:
+      endpointAddress: http://localhost:9411/api/v2/spans

--- a/lib/hr/Makefile
+++ b/lib/hr/Makefile
@@ -2,10 +2,13 @@ app := hr
 image := ghcr.io/redbadger/$(app)
 tag := latest
 
+workspace-root := $(shell git rev-parse --show-toplevel)
+dapr-config := $(workspace-root)/dapr-config-slim.yaml
+
 .PHONY: dev
 dev: ## Start the server and watch for changes, using `dapr run` standalone mode.
 	dapr run \
-		--config ../../dapr-config-slim.yaml \
+		--config $(dapr-config) \
 		--app-id hr \
 		--app-port 3000 \
 		-- cargo watch -x run

--- a/lib/slack/Dockerfile
+++ b/lib/slack/Dockerfile
@@ -9,7 +9,7 @@ RUN pnpm fetch
 
 COPY . .
 # For pnpm, this is just hardlinking a bunch of directories, so it's basically free.
-RUN pnpm install --offline --dev
+RUN pnpm install --offline
 RUN NODE_ENV=production pnpm build
 RUN pnpm prune --prod
 

--- a/lib/slack/Makefile
+++ b/lib/slack/Makefile
@@ -2,11 +2,14 @@ app := slack
 image := ghcr.io/redbadger/$(app)
 tag := latest
 
+workspace-root := $(shell git rev-parse --show-toplevel)
+dapr-config := $(workspace-root)/dapr-config-slim.yaml
+
 .PHONY: dev
 dev: ## Start the server and watch for changes, using `dapr run` standalone mode.
 	pnpm install
 	dapr run \
-		--config ../../dapr-config-slim.yaml \
+		--config $(dapr-config) \
 		--app-id slack \
 		--app-port 3001 \
 		-- pnpm dev

--- a/lib/slack/package.json
+++ b/lib/slack/package.json
@@ -5,10 +5,19 @@
   "license": "MIT",
   "scripts": {
     "start": "ts-node src/index.ts",
-    "dev": "concurrently \"tsc -w --preserveWatchOutput\" \"nodemon dist/index.js\"",
+    "dev": "concurrently --kill-others \"tsc -w --preserveWatchOutput\" \"nodemon dist/index.js\"",
     "build": "tsc"
   },
   "dependencies": {
+    "@opentelemetry/api": "^0.21.0",
+    "@opentelemetry/core": "^0.21.0",
+    "@opentelemetry/exporter-zipkin": "^0.21.0",
+    "@opentelemetry/instrumentation-express": "^0.21.0",
+    "@opentelemetry/instrumentation-http": "^0.21.0",
+    "@opentelemetry/instrumentation": "^0.21.0",
+    "@opentelemetry/node": "^0.21.0",
+    "@opentelemetry/resources": "^0.21.0",
+    "@opentelemetry/tracing": "^0.21.0",
     "express": "^4.17.1",
     "node-fetch": "^2.6.1"
   },

--- a/lib/slack/pnpm-lock.yaml
+++ b/lib/slack/pnpm-lock.yaml
@@ -1,6 +1,15 @@
 lockfileVersion: 5.3
 
 specifiers:
+  '@opentelemetry/api': ^0.21.0
+  '@opentelemetry/core': ^0.21.0
+  '@opentelemetry/exporter-zipkin': ^0.21.0
+  '@opentelemetry/instrumentation': ^0.21.0
+  '@opentelemetry/instrumentation-express': ^0.21.0
+  '@opentelemetry/instrumentation-http': ^0.21.0
+  '@opentelemetry/node': ^0.21.0
+  '@opentelemetry/resources': ^0.21.0
+  '@opentelemetry/tracing': ^0.21.0
   '@types/express': ^4.17.11
   '@types/node': ^14.14.37
   '@types/node-fetch': ^2.5.10
@@ -12,6 +21,15 @@ specifiers:
   typescript: ^4.2.3
 
 dependencies:
+  '@opentelemetry/api': 0.21.0
+  '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+  '@opentelemetry/exporter-zipkin': 0.21.0_@opentelemetry+api@0.21.0
+  '@opentelemetry/instrumentation': 0.21.0_@opentelemetry+api@0.21.0
+  '@opentelemetry/instrumentation-express': 0.21.0_@opentelemetry+api@0.21.0
+  '@opentelemetry/instrumentation-http': 0.21.0_@opentelemetry+api@0.21.0
+  '@opentelemetry/node': 0.21.0_@opentelemetry+api@0.21.0
+  '@opentelemetry/resources': 0.21.0_@opentelemetry+api@0.21.0
+  '@opentelemetry/tracing': 0.21.0_@opentelemetry+api@0.21.0
   express: 4.17.1
   node-fetch: 2.6.1
 
@@ -47,6 +65,161 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
+  /@opentelemetry/api-metrics/0.21.0_@opentelemetry+api@0.21.0:
+    resolution: {integrity: sha512-s3mhqJdV04DFL59lhp7wR5UMCpJu6BN7PWJRokjXs/St5NIsYjWt5G0OlsrN58/OgSIVl2pdPbVG2QhASvhSpw==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^0.21.0
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+    dev: false
+
+  /@opentelemetry/api/0.21.0:
+    resolution: {integrity: sha512-Q7hHb3nidPgnBS2fi+y3K64F3EV48d9v09/6EtigIgVF43NFNhw/dboDKC7gECEkbTwuvFeLCbwKs9JaC8LDEw==}
+    engines: {node: '>=8.0.0'}
+    dev: false
+
+  /@opentelemetry/context-async-hooks/0.21.0_@opentelemetry+api@0.21.0:
+    resolution: {integrity: sha512-3XxzT7jiDLbohUy66NWsYuWFtXsMI0qMhetWVlFmmBfMPLMR+U6xWA4xhfRMb6kMEjR5XJHbyDSxYwzxrd10sg==}
+    engines: {node: '>=8.1.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^0.21.0
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+    dev: false
+
+  /@opentelemetry/core/0.21.0_@opentelemetry+api@0.21.0:
+    resolution: {integrity: sha512-sZZQThBuqhCdBPgzPq4y9L4dhnpXXCCEqNsR6IUmMc/kQ8Bcw3lmI5fymLlliSt+lnTc26xJPVKZlwoQfwhThg==}
+    engines: {node: '>=8.5.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^0.21.0
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/semantic-conventions': 0.21.0
+      semver: 7.3.5
+    dev: false
+
+  /@opentelemetry/exporter-zipkin/0.21.0_@opentelemetry+api@0.21.0:
+    resolution: {integrity: sha512-Y97AVc2aMJXsBgIzzLJgXxZA8pBFoO1GIr8O9KW9TftY/X/BaZyNRV2uLc3nvHB3GLCHRKqWPt3B15Zodjdodw==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^0.21.0
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/resources': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/semantic-conventions': 0.21.0
+      '@opentelemetry/tracing': 0.21.0_@opentelemetry+api@0.21.0
+    dev: false
+
+  /@opentelemetry/instrumentation-express/0.21.0_@opentelemetry+api@0.21.0:
+    resolution: {integrity: sha512-ZHZsJ9nRliuBRSYJrekEhgC/qGHPIADt90SUYUmcrQ8nscsCiR8Aay+7n1P9QwkyezZxhh32t3uROR+2onw1VA==}
+    engines: {node: '>=8.5.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^0.21.0
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/instrumentation': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/semantic-conventions': 0.21.0
+      '@types/express': 4.17.12
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-http/0.21.0_@opentelemetry+api@0.21.0:
+    resolution: {integrity: sha512-OE3hw93FQQtkleKY46cFXI8gGm6vfSWmeFt6hvmBbNcLioB2GGVupVBuGRKsxo/IVDfBeQ7zocNJkwtrYJMrVg==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^0.21.0
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/instrumentation': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/semantic-conventions': 0.21.0
+      semver: 7.3.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation/0.21.0_@opentelemetry+api@0.21.0:
+    resolution: {integrity: sha512-OeV6wobxPjYQxEoeepliV4OyAAfoCseO66BP6Rr20nItTcjR0ZKZtpyPoDa0XVWXLtl0N/aMnzZ6I4o08KQNrQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^0.21.0
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/api-metrics': 0.21.0_@opentelemetry+api@0.21.0
+      require-in-the-middle: 5.1.0
+      semver: 7.3.5
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/node/0.21.0_@opentelemetry+api@0.21.0:
+    resolution: {integrity: sha512-PCA3pFmzTMN3iIlZ6Bz2BgPe8jEIdKRK7WyjfT9qqrLrHZ/dXNmX4MIz2IKTyQtS6tGt2jayD0IpWsVFctPOIA==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^0.21.0
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/context-async-hooks': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/propagator-b3': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/propagator-jaeger': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/tracing': 0.21.0_@opentelemetry+api@0.21.0
+      semver: 7.3.5
+    dev: false
+
+  /@opentelemetry/propagator-b3/0.21.0_@opentelemetry+api@0.21.0:
+    resolution: {integrity: sha512-KXQKXa76ilzBNdwr7hze9251g0AqBmwhCPnt17UCgb+97DFcOyEy5Rc7nnjZNxNGYYqUbk8116MK9hMZO2icGw==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^0.21.0
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+    dev: false
+
+  /@opentelemetry/propagator-jaeger/0.21.0_@opentelemetry+api@0.21.0:
+    resolution: {integrity: sha512-H0TaYBvDi4stz19UJNPFR1IRikQYjoKYuV6tZV4V5NnPAFTjBhvj/Heb0fNDUWK5G1tVB5NPrEsNSZjjdfvjLw==}
+    engines: {node: '>=8.5.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^0.21.0
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+    dev: false
+
+  /@opentelemetry/resources/0.21.0_@opentelemetry+api@0.21.0:
+    resolution: {integrity: sha512-xQUL2/2npP/isH8sbOSdynIRWmlM6p02L9Ex8x/BhUuSkGrMoxO2ezLPPYnfYam1py6ubaz8m1C54O2IRCmgQQ==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^0.21.0
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/semantic-conventions': 0.21.0
+    dev: false
+
+  /@opentelemetry/semantic-conventions/0.21.0:
+    resolution: {integrity: sha512-qQtZJ8Q+bO/gemBELsZbz5s//tNnyc+mQD/0RHc77XhI6ZBb+tprU6KN/7l0fl5z29smmai0hcJ9UNILC/7nIw==}
+    engines: {node: '>=8.0.0'}
+    dev: false
+
+  /@opentelemetry/tracing/0.21.0_@opentelemetry+api@0.21.0:
+    resolution: {integrity: sha512-6+2pfFpu7Yo2DwmBK9sHDUSIL7UshcEMwDF6+LghGK68ILRaEMqqBPgKarjhFH9ERgJB9GOkJ2snK96qIzMZNA==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^0.21.0
+    dependencies:
+      '@opentelemetry/api': 0.21.0
+      '@opentelemetry/core': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/resources': 0.21.0_@opentelemetry+api@0.21.0
+      '@opentelemetry/semantic-conventions': 0.21.0
+      lodash.merge: 4.6.2
+    dev: false
+
   /@sindresorhus/is/0.14.0:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
     engines: {node: '>=6'}
@@ -64,13 +237,11 @@ packages:
     dependencies:
       '@types/connect': 3.4.34
       '@types/node': 14.17.3
-    dev: true
 
   /@types/connect/3.4.34:
     resolution: {integrity: sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==}
     dependencies:
       '@types/node': 14.17.3
-    dev: true
 
   /@types/express-serve-static-core/4.17.21:
     resolution: {integrity: sha512-gwCiEZqW6f7EoR8TTEfalyEhb1zA5jQJnRngr97+3pzMaO1RKoI1w2bw07TK72renMUVWcWS5mLI6rk1NqN0nA==}
@@ -78,7 +249,6 @@ packages:
       '@types/node': 14.17.3
       '@types/qs': 6.9.6
       '@types/range-parser': 1.2.3
-    dev: true
 
   /@types/express/4.17.12:
     resolution: {integrity: sha512-pTYas6FrP15B1Oa0bkN5tQMNqOcVXa9j4FTFtO8DWI9kppKib+6NJtfTOOLcwxuuYvcX2+dVG6et1SxW/Kc17Q==}
@@ -87,11 +257,9 @@ packages:
       '@types/express-serve-static-core': 4.17.21
       '@types/qs': 6.9.6
       '@types/serve-static': 1.13.9
-    dev: true
 
   /@types/mime/1.3.2:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
-    dev: true
 
   /@types/node-fetch/2.5.10:
     resolution: {integrity: sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==}
@@ -102,7 +270,6 @@ packages:
 
   /@types/node/14.17.3:
     resolution: {integrity: sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==}
-    dev: true
 
   /@types/normalize-package-data/2.4.0:
     resolution: {integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==}
@@ -110,18 +277,15 @@ packages:
 
   /@types/qs/6.9.6:
     resolution: {integrity: sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==}
-    dev: true
 
   /@types/range-parser/1.2.3:
     resolution: {integrity: sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==}
-    dev: true
 
   /@types/serve-static/1.13.9:
     resolution: {integrity: sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==}
     dependencies:
       '@types/mime': 1.3.2
       '@types/node': 14.17.3
-    dev: true
 
   /abbrev/1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -434,6 +598,18 @@ packages:
       ms: 2.1.3
     dev: true
 
+  /debug/4.3.1:
+    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: false
+
   /decompress-response/3.3.0:
     resolution: {integrity: sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=}
     engines: {node: '>=4'}
@@ -617,7 +793,6 @@ packages:
 
   /function-bind/1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
-    dev: true
 
   /get-caller-file/2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -693,7 +868,6 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
-    dev: true
 
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -789,7 +963,6 @@ packages:
     resolution: {integrity: sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==}
     dependencies:
       has: 1.0.3
-    dev: true
 
   /is-extglob/2.1.1:
     resolution: {integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=}
@@ -878,6 +1051,10 @@ packages:
     resolution: {integrity: sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=}
     dev: true
 
+  /lodash.merge/4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: false
+
   /lodash/4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: true
@@ -891,6 +1068,13 @@ packages:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
     dev: true
+
+  /lru-cache/6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+    dependencies:
+      yallist: 4.0.0
+    dev: false
 
   /make-dir/3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -948,11 +1132,19 @@ packages:
     resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
     dev: true
 
+  /module-details-from-path/1.0.3:
+    resolution: {integrity: sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=}
+    dev: false
+
   /ms/2.0.0:
     resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=}
 
   /ms/2.1.1:
     resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
+    dev: false
+
+  /ms/2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: false
 
   /ms/2.1.3:
@@ -1058,7 +1250,6 @@ packages:
 
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
 
   /path-to-regexp/0.1.7:
     resolution: {integrity: sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=}
@@ -1166,12 +1357,21 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /require-in-the-middle/5.1.0:
+    resolution: {integrity: sha512-M2rLKVupQfJ5lf9OvqFGIT+9iVLnTmjgbOmpil12hiSQNn5zJTKGPoIisETNjfK+09vP3rpm1zJajmErpr2sEQ==}
+    dependencies:
+      debug: 4.3.1
+      module-details-from-path: 1.0.3
+      resolve: 1.20.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /resolve/1.20.0:
     resolution: {integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==}
     dependencies:
       is-core-module: 2.4.0
       path-parse: 1.0.7
-    dev: true
 
   /responselike/1.0.2:
     resolution: {integrity: sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=}
@@ -1211,6 +1411,14 @@ packages:
     hasBin: true
     dev: true
 
+  /semver/7.3.5:
+    resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
+
   /send/0.17.1:
     resolution: {integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==}
     engines: {node: '>= 0.8.0'}
@@ -1242,6 +1450,10 @@ packages:
 
   /setprototypeof/1.1.1:
     resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
+    dev: false
+
+  /shimmer/1.2.1:
+    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
     dev: false
 
   /signal-exit/3.0.3:
@@ -1532,6 +1744,10 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
     dev: true
+
+  /yallist/4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: false
 
   /yargs-parser/20.2.7:
     resolution: {integrity: sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==}

--- a/lib/slack/src/index.ts
+++ b/lib/slack/src/index.ts
@@ -1,3 +1,5 @@
+import './tracer'
+
 import express, { response } from 'express'
 import fetch from 'node-fetch';
 import { getUserName } from './core';

--- a/lib/slack/src/tracer.ts
+++ b/lib/slack/src/tracer.ts
@@ -1,0 +1,27 @@
+import opentelemetry from '@opentelemetry/api'
+import { registerInstrumentations } from '@opentelemetry/instrumentation'
+import { NodeTracerProvider } from '@opentelemetry/node'
+import { SimpleSpanProcessor } from '@opentelemetry/tracing'
+import { ZipkinExporter } from '@opentelemetry/exporter-zipkin'
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
+import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express'
+import { Resource } from '@opentelemetry/resources'
+
+const installTracing = () => {
+  const provider = new NodeTracerProvider({
+    resource: new Resource({ 'service.name': 'slack-ts' }),
+  })
+
+  const exporter = new ZipkinExporter()
+
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter))
+
+  // Initialize the OpenTelemetry APIs to use the NodeTracerProvider bindings
+  provider.register()
+
+  registerInstrumentations({
+    instrumentations: [new HttpInstrumentation(), new ExpressInstrumentation()],
+  })
+}
+
+installTracing()


### PR DESCRIPTION
This is based on top of #20, so we probably want to review that first and get it merged.

The dapr zipkin integration manages to show single-hop dependencies between services, because all inter-service traffic goes via the sidecar. It wouldn't let you debug a call that gets threaded via multiple services though, because it doesn't have anything telling it "this downstream http request was made because we are handling this upstream http request". For this, you need to add instrumentation into the app.

This PR adds opentelemetry auto-instrumentation to link up express -> fetch within the slack api. This allows you to get traces like this:

<img width="712" alt="Screenshot 2021-06-18 at 16 56 32" src="https://user-images.githubusercontent.com/254647/122587773-25826700-d056-11eb-81df-732a0ea72792.png">


OpenTelemetry is a whole bunch of boilerplate that takes me all day to set up every time I set it up (and I've not even touched our logging or the rust service), because they insist on exposing all the complexity all the time. I really wish there was a simple package where you say "please instrument all the things you can find, and send them to zipkin with service name 'slack-ts'". 